### PR TITLE
Added shortcuts for common set symbols

### DIFF
--- a/mathbot/help/latex.md
+++ b/mathbot/help/latex.md
@@ -36,3 +36,7 @@ Examples
 `The answer is $$x^{2 + y}$$.`
 
 `$$1 + 2$$ equals $$3$$.`
+
+## Custom commands
+
+Some custom commands have been added to make typing quick LaTeX easy. These include `\bbR`, `\bbN` etc. for `\mathbb{R}`, `mathbb{N}` and other common set symbols and `\bigO` for `\mathcal{O}`

--- a/mathbot/modules/latex.py
+++ b/mathbot/modules/latex.py
@@ -53,7 +53,7 @@ PREAMBLE = r'''
 \newcommand{\bbC}{\mathbb{C}}
 \newcommand{\bbZ}{\mathbb{Z}}
 \newcommand{\bbN}{\mathbb{N}}
-
+\newcommand{\bigO}{\mathcal{O}}
 '''
 
 TEMPLATE = r'''

--- a/mathbot/modules/latex.py
+++ b/mathbot/modules/latex.py
@@ -52,6 +52,8 @@ PREAMBLE = r'''
 \newcommand{\bbQ}{\mathbb{Q}}
 \newcommand{\bbC}{\mathbb{C}}
 \newcommand{\bbZ}{\mathbb{Z}}
+\newcommand{\bbN}{\mathbb{N}}
+
 '''
 
 TEMPLATE = r'''

--- a/mathbot/modules/latex.py
+++ b/mathbot/modules/latex.py
@@ -47,6 +47,11 @@ PREAMBLE = r'''
 \mathchardef\qof    = "0\declfam 72
 \mathchardef\lamed  = "0\declfam 6C
 \mathchardef\mim    = "0\declfam 6D
+
+\newcommand{\bbR}{\mathbb{R}}
+\newcommand{\bbQ}{\mathbb{Q}}
+\newcommand{\bbC}{\mathbb{C}}
+\newcommand{\bbZ}{\mathbb{Z}}
 '''
 
 TEMPLATE = r'''


### PR DESCRIPTION
As suggested by `@PackSciences` on Discord. Use `\bb<letter>`. For example `\bbR` for `\mathbb{R}`