### PR TITLE
calculator: correct is_complex typo

### DIFF
--- a/mathbot/calculator/calculator.py
+++ b/mathbot/calculator/calculator.py
@@ -297,7 +297,7 @@ def is_real(x):
 	return oneify(isinstance(x, int) or isinstance(x, float))
 
 
-def is_comlpex(x):
+def is_complex(x):
 	return oneify(isinstance(x, complex))
 
 
@@ -412,7 +412,7 @@ BUILTIN_FUNCTIONS = {
 	'lcm': calculator.operators.function_lcm,
 	'choose': m_choose,
 	'is_real': is_real,
-	'is_complex': is_comlpex,
+	'is_complex': is_complex,
 	'is_function': is_function,
 	'length': array_length,
 	'join': array_join,


### PR DESCRIPTION
is_comlpex -> is_complex

This doesn't affect normal usage of the bot, since the function itself is still called `is_complex`.