### PR TITLE
Make scripts executable and add shebang lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__
 ignore
 keystore.json
 parameters.json
+# virtualenv directory
+venv/

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-single: cd mathbot && python bot.py PARAMETERS.env
-jade: cd mathbot && python bot.py PARAMETERS.env '{"shards": {"mine": [0, 1]}}'
-onyx: cd mathbot && python bot.py PARAMETERS.env '{"shards": {"mine": [2, 3]}}'
+single: cd mathbot && ./bot.py PARAMETERS.env
+jade: cd mathbot && ./bot.py PARAMETERS.env '{"shards": {"mine": [0, 1]}}'
+onyx: cd mathbot && ./bot.py PARAMETERS.env '{"shards": {"mine": [2, 3]}}'

--- a/gendoc
+++ b/gendoc
@@ -1,5 +1,7 @@
+#!/usr/bin/env sh
 # Generate the documentation from help files
+
 cd mathbot
-python generate_docs_page.py
+./generate_docs_page.py
 cd ..
 mv mathbot/docs.html docs.html

--- a/mathbot/bot.py
+++ b/mathbot/bot.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
 import sys
 import os
 import asyncio

--- a/mathbot/calculator/attempt6.py
+++ b/mathbot/calculator/attempt6.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
 import json
 import re
 

--- a/mathbot/generate_docs_page.py
+++ b/mathbot/generate_docs_page.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
 import markdown
 import core.help
 import modules.help

--- a/mathbot/tests/test_calculator.py
+++ b/mathbot/tests/test_calculator.py
@@ -87,7 +87,7 @@ def test_unicode():
 	doit('3×2', 6)
 	doit('6÷2', 3)
 	doit('π', math.pi)
-	doit('τ', math.tau)
+	doit('τ', 2 * math.pi)
 	doit('5*0', 0)
 
 def test_dice_rolling():

--- a/test
+++ b/test
@@ -1,4 +1,6 @@
+#!/usr/bin/env sh
 # This script runs the unit tests
+
 cd mathbot
 python -m pytest tests
 cd ..


### PR DESCRIPTION
Rationale:
- In ./gendoc, for example, `python generate_docs_page.py` is called.
However, on some (most) systems, `python` is actually python2.7.
By calling `./generate_docs_page.py`, the interpreter specified in
the shebang line is used instead.

- In order for scripts to be executed as ./script.py,
they must have the proper permissions set.

- Also add `# encoding: utf-8` lines to those scripts that now have
the shebang.

Minor changes:
- Ignore venv/ directories, for virtualenvs
- Fix the `test_calculator.test_unicode()` function for those not yet running python3.6.