### PR TITLE
Remove "bogan" from bad_words.txt

### DIFF
--- a/mathbot/wordfilter/bad_words.txt
+++ b/mathbot/wordfilter/bad_words.txt
@@ -75,7 +75,6 @@ bitchy
 blackout
 blowjob
 boang
-bogan
 bohunk
 bollick
 bollock


### PR DESCRIPTION
Bogan is not offensive, e.g. It is used in the title of a mainstream TV show by the ABC https://en.wikipedia.org/wiki/Upper_Middle_Bogan