### PR TITLE
calculator.__main__: handle EOF and blank lines

### DIFF
--- a/mathbot/calculator/__main__.py
+++ b/mathbot/calculator/__main__.py
@@ -56,13 +56,15 @@ def print_token_parse_caret(to):
 
 
 def interactive_terminal():
-
 	terminal = Terminal(allow_special_commands = True, yield_rate = 1)
 
 	while True:
-		line = input('> ')
-		if line == '':
+		try:
+			line = input('> ')
+		except EOFError:
 			break
+		if line == '':
+			continue
 		output, worked, details = terminal.execute(line)
 		print(output)
 


### PR DESCRIPTION
Stops the REPL from quitting when you press enter and erroring out when you press CTRL+D.