### PR TITLE
mathbot/modules/calcmod/perform_calculation: properly escape mentions…

### DIFF
--- a/mathbot/modules/calcmod.py
+++ b/mathbot/modules/calcmod.py
@@ -116,10 +116,9 @@ class CalculatorModule(core.module.Module):
 			elif result.count('\n') > 0:
 				result = '```\n{}\n```'.format(result)
 			else:
-				result = result.replace('*', '\\*')
-				result = result.replace('_', '\\_')
-				result = result.replace('#', '\\#')
-				result = result.replace('@', '\\@')
+				for special_char in ('*', '\\', '_', '~~', '`'):
+					result = result.replace(special_char, '\\' + special_char)
+				result = result.replace('@', '\N{zero width non-joiner}@')
 			if result == '':
 				result = ':thumbsup:'
 			elif len(result) > 2000:

--- a/mathbot/modules/calcmod.py
+++ b/mathbot/modules/calcmod.py
@@ -118,7 +118,7 @@ class CalculatorModule(core.module.Module):
 			else:
 				for special_char in ('*', '\\', '_', '~~', '`'):
 					result = result.replace(special_char, '\\' + special_char)
-				result = result.replace('@', '\N{zero width non-joiner}@')
+				result = result.replace('@', '@\N{zero width non-joiner}')
 			if result == '':
 				result = ':thumbsup:'
 			elif len(result) > 2000:


### PR DESCRIPTION
… and other chars

"#" doesn't need escaping since it doesn't affect anyone else and it's always in the special form <#ID>.