### PR TITLE
Display individual rolls, and support greater number of dice/faces

### DIFF
--- a/mathbot/core/settings.py
+++ b/mathbot/core/settings.py
@@ -19,7 +19,8 @@ SETTINGS = {
 	'f-delete-tex': {'default': False},
 	'f-tex-inline': {'redirect': 'f-inline-tex'},
 	'f-tex-delete': {'redirect': 'f-delete-tex'},
-	'm-disabled-cmd': {'default': True}
+	'f-roll-unlimited': {'default': False},
+	'm-disabled-cmd': {'default': True},
 }
 
 

--- a/mathbot/help/roll.md
+++ b/mathbot/help/roll.md
@@ -4,4 +4,6 @@
 
 `{{prefix}}roll number faces`
 
+The amount of dice shown is by default limited, if you wish to remove this limit you can enable the setting `f-roll-unlimited`.
+
 Example: `{{prefix}}roll 2d8`

--- a/mathbot/help/settings.md
+++ b/mathbot/help/settings.md
@@ -36,6 +36,7 @@ These settings can be applied to the `server` and `channel` contexts, but only b
 - `f-tex-delete`: When enabled, the bot will delete messages used to invoke the tex command after a few seconds. Default: *Disabled*.
 - `f-wolf-filter`: Toggles the word filter for W|A queries. This is enabled by default for all non-nsfw channels.
 - `f-wolf-mention`: Toggles the `@mention` in the footer of W|A results. Default: *Enabled*.
+- `f-roll-unlimited`: When enabled there is no limit (apart from the discord message limit) to the amount of rolls shown with the roll command.
 - `m-disabled-cmd`: Toggles the "That command cannot be used in this location" message. Default: *Enabled*.
 
 :::page-break

--- a/mathbot/modules/dice.py
+++ b/mathbot/modules/dice.py
@@ -77,10 +77,10 @@ class DiceModule(core.module.Module):
 		rolling more times than limit.
 		'''
 		if math.log10(dice) < 16 and\
-			math.log10(faces) < 16 and\
+			math.log10(faces) < 8 and\
 			math.log10(dice * faces) < 16:
 			return self.gaussian_roll_single(dice, faces)
-		elif math.log10(faces) < 16:
+		elif math.log10(faces) < 8:
 			dice_per = 16 - round(math.log10(faces))
 			times = round(dice / 10**(dice_per))
 			if times > limit:
@@ -95,7 +95,7 @@ class DiceModule(core.module.Module):
 		inaccuracies rather easily. In order to avoid float inaccuracy you'll need
 		to make sure that:
 		1. dice has fewer than 16 digits
-		2. faces has fewer than 16 digits
+		2. faces has fewer than 8 digits
 		3. dice and faces have fewer than 16 digits combined
 		'''
 		mean = (faces + 1) * dice / 2

--- a/mathbot/modules/dice.py
+++ b/mathbot/modules/dice.py
@@ -5,6 +5,7 @@ import asyncio
 import core.module
 import core.handles
 import core.help
+import core.settings
 
 core.help.load_from_file('./help/roll.md')
 
@@ -25,9 +26,16 @@ class DiceModule(core.module.Module):
 			return '🎲 Values are too large. Cannot be greater than 100000.'
 
 		rolls, total = self.formatted_roll(dice, faces)
-		message = f'🎲 {rolls}'
-		return message if len(message) <= 2000 else f'🎲 total: {total}'
-	
+		final_message = f'🎲 {rolls}'
+		limit = await self.get_limit(message)
+		print(limit)
+		return final_message if len(final_message) <= limit else f'🎲 total: {total}'
+
+	async def get_limit(self, message):
+		unlimited = await core.settings.resolve_message('f-roll-unlimited', message)
+		print(unlimited)
+		return 100 if not unlimited else 2000
+
 	def formatted_roll(self, dice, faces):
 		rolls = [random.randint(1, faces) for _ in range(dice)]
 		s = f'{str.join(" ", (str(i) for i in rolls))} (total: {sum(rolls)})'

--- a/mathbot/modules/dice.py
+++ b/mathbot/modules/dice.py
@@ -23,5 +23,12 @@ class DiceModule(core.module.Module):
 		faces = int(faces or 6)
 		if faces > 100000 or dice > 100000:
 			return '🎲 Values are too large. Cannot be greater than 100000.'
-		total = sum(random.randint(1, faces) for i in range(dice))
-		return f'🎲 {total}'
+
+		rolls, total = self.formatted_roll(dice, faces)
+		message = f'🎲 {rolls}'
+		return message if len(message) <= 2000 else f'🎲 total: {total}'
+	
+	def formatted_roll(self, dice, faces):
+		rolls = [random.randint(1, faces) for _ in range(dice)]
+		s = f'{str.join(" ", (str(i) for i in rolls))} (total: {sum(rolls)})'
+		return s, sum(rolls)

--- a/mathbot/modules/dice.py
+++ b/mathbot/modules/dice.py
@@ -14,10 +14,7 @@ core.help.load_from_file('./help/roll.md')
 FORMAT_REGEX = re.compile(r'^(?:(\d*)[ d]+)?(\d+)$')
 
 
-class TooManyFacesException(Exception): pass
-
-
-class TooManyDiceException(Exception): pass
+class TooBigValuesException(Exception): pass
 
 
 class DiceModule(core.module.Module):
@@ -46,10 +43,8 @@ class DiceModule(core.module.Module):
 			total = 0
 			try:
 				total = self.gaussian_roll(dice, faces)
-			except TooManyDiceException:
-				return '🎲 You have tried to roll too many dice.'
-			except TooManyFacesException:
-				return '🎲 You have tried to roll too many faces.'
+			except TooBigValuesException:
+				return '🎲 Values are too large.'
 
 			return f'🎲 total: {total}'
 		else:
@@ -79,19 +74,19 @@ class DiceModule(core.module.Module):
 		'''
 
 		# if it passes this first test, then it's safe to do it in one roll
-		if math.log10(dice) < 16 and\
-			math.log10(faces) < 8 and\
-			math.log10(dice * faces) < 16:
+		if math.log2(dice) < 53 and\
+			math.log2(faces) < 26 and\
+			math.log2(dice * faces) < 53:
 			return self.gaussian_roll_single(dice, faces)
 		# passing this second test means we can do multiple rolls safely
-		elif math.log10(faces) < 8:
-			dice_per = 16 - round(math.log10(faces))
-			times = round(dice / 10**(dice_per))
+		elif math.log2(faces) < 26:
+			dice_per = 53 - round(math.log2(faces))
+			times = round(dice / 2**(dice_per))
 			if times > limit:
-				raise TooManyDiceException()
+				raise TooBigValuesException()
 			return sum([self.gaussian_roll_single(dice_per, faces) for _ in range(times)])
 		else:
-			raise TooManyFacesException()
+			raise TooBigValuesException()
 
 	def gaussian_roll_single(self, dice, faces):
 		'''

--- a/mathbot/modules/dice.py
+++ b/mathbot/modules/dice.py
@@ -41,6 +41,7 @@ class DiceModule(core.module.Module):
 		# this is the minimal length of this query
 		min_len = 2 * dice + 9 + math.log10(dice)
 
+		# gaussian roll is faster so try that if we can't show all the rolls
 		if min_len >= limit:
 			total = 0
 			try:
@@ -60,7 +61,7 @@ class DiceModule(core.module.Module):
 		'''This method gets the character limit for messages.'''
 		unlimited = await core.settings.resolve_message('f-roll-unlimited', message)
 		print(unlimited)
-		return 100 if not unlimited else 2000
+		return 200 if not unlimited else 2000
 
 	def formatted_roll(self, dice, faces):
 		'''
@@ -76,10 +77,13 @@ class DiceModule(core.module.Module):
 		many times as neccessary to avoid float inaccuracy, unless that means
 		rolling more times than limit.
 		'''
+
+		# if it passes this first test, then it's safe to do it in one roll
 		if math.log10(dice) < 16 and\
 			math.log10(faces) < 8 and\
 			math.log10(dice * faces) < 16:
 			return self.gaussian_roll_single(dice, faces)
+		# passing this second test means we can do multiple rolls safely
 		elif math.log10(faces) < 8:
 			dice_per = 16 - round(math.log10(faces))
 			times = round(dice / 10**(dice_per))

--- a/mathbot/tests/test_using_automata.py
+++ b/mathbot/tests/test_using_automata.py
@@ -176,7 +176,8 @@ async def test_dice_rolling(interface):
     for i in ['', 'x', '1 2 3', '3d']:
         await interface.assert_reply_contains('=roll ' + i, 'Format your rolls like')
     for i in ['1000000', '100001', '800000 d 1', '500000 500000']:
-        await interface.assert_reply_contains('=roll ' + i, 'Values are too large.')
+        message = await interface.wait_for_reply('=roll ' + i)
+        assert 'went wrong' not in message.content
     for i in ['6', 'd6', '1d6', '1 6', '1 d 6']:
         message = await interface.wait_for_reply('=roll ' + i)
-        assert(int(message.content[2:]) in range(1, 7))
+        assert int(message.content[2]) in range(1, 7)


### PR DESCRIPTION
The roll command now shows each individual roll, unless the message would be too long. The default limit is 200 but can be increased if you enable `f-roll-unlimited`.

If the amount of faces/dice is too large to display each individual roll, it'll (probably) try to use a normal distribution to calculate the dice roll. Thanks to Ann for figuring out the formula.

The limit to dice/faces is not as simple as it used to be, now i have it set such that it avoids float inaccuracy. This means that it will do single calculations if it can, but if it would be too inaccurate it'll try (up to) 100 000 single calculations. If this is exceeded it'll complain about the values being too large.

**examples:**
```
=roll 5d6
🎲 2 6 4 5 4 (total: 21)
```

```
=roll 100d24
🎲 total: 1192
```