### PR TITLE
Added circuit drawing package

### DIFF
--- a/mathbot/modules/latex/template.tex
+++ b/mathbot/modules/latex/template.tex
@@ -6,7 +6,7 @@
 \usepackage{amssymb}
 \usepackage{mathrsfs}
 \usepackage{chemfig}
-\usepackage[siunitx, american, european]{circuitikz}
+\usepackage[siunitx, american]{circuitikz}
 \usepackage{mathtools}
 \usepackage{mhchem}
 \usepackage{tikz-cd}

--- a/mathbot/modules/latex/template.tex
+++ b/mathbot/modules/latex/template.tex
@@ -6,7 +6,8 @@
 \usepackage{amssymb}
 \usepackage{mathrsfs}
 \usepackage{chemfig}
-\usepackage{tikz}
+\usepackage[siunitx, american, european]{circuitikz}
+\usepackage{mathtools}
 \usepackage{mhchem}
 \usepackage{tikz-cd}
 \usepackage{color}

--- a/mathbot/modules/latex/template.tex
+++ b/mathbot/modules/latex/template.tex
@@ -1,7 +1,6 @@
 \documentclass{article}
 
 \usepackage[utf8]{inputenc}
-\usepackage{amsmath}
 \usepackage{amsfonts}
 \usepackage{amssymb}
 \usepackage{mathrsfs}


### PR DESCRIPTION
Replaced `\usepackage{tikz}` with `\usepackage[siunitx, american, european]{circuitikz}`. (The `circuitikz` package automatically loads `tikz`.)

Example circuit: [gist](https://gist.github.com/Froths/3d9e305b9df2e5e9f5c333d31c33f580)

&nbsp;

Also added `\usepackage{mathtools}` for the ability to box lines with alignment (&) characters via `\Aboxed`. (The regular `\boxed` command from `amsmath` fails in this case.)