### PR TITLE
wordfilter: ignore all non-ascii

### DIFF
--- a/mathbot/wordfilter/__init__.py
+++ b/mathbot/wordfilter/__init__.py
@@ -1,16 +1,16 @@
 import string
 import os
 
-
+ASCII_LOWERCASE = set(string.ascii_lowercase)  # fast containment check
 WORDFILE = os.path.dirname(os.path.abspath(__file__)) + '/bad_words.txt'
 BAD_WORDS = set()
 
 with open(WORDFILE) as f:
-	for i in map(str.strip, f):
-		BAD_WORDS |= {i, i + 's', i + 'ed'}
+	for word in map(str.strip, f):
+		BAD_WORDS |= {word, word + 's', word + 'ed'}
 
 
 def is_bad(sentence):
-	s = sentence.replace('\u200B', '')
-	s = ''.join(map(lambda c: c if c in string.ascii_letters else ' ', s))
-	return bool(set(s.lower().split(' ')) & BAD_WORDS)
+	words = s.lower().split()
+	words = (''.join(map(lambda c: c if c in ASCII_LOWERCASE else '', word)) for word in words)
+	return bool(set(words) & BAD_WORDS)

--- a/mathbot/wordfilter/__init__.py
+++ b/mathbot/wordfilter/__init__.py
@@ -1,6 +1,7 @@
 import string
 import os
 
+
 ASCII_LOWERCASE = set(string.ascii_lowercase)  # fast containment check
 WORDFILE = os.path.dirname(os.path.abspath(__file__)) + '/bad_words.txt'
 BAD_WORDS = set()
@@ -9,8 +10,7 @@ with open(WORDFILE) as f:
 	for word in map(str.strip, f):
 		BAD_WORDS |= {word, word + 's', word + 'ed'}
 
-
 def is_bad(sentence):
-	words = s.lower().split()
+	words = sentence.lower().split()
 	words = (''.join(map(lambda c: c if c in ASCII_LOWERCASE else '', word)) for word in words)
 	return bool(set(words) & BAD_WORDS)


### PR DESCRIPTION
removes all non-ascii chars from each word
also uses set(string.ascii_lowercase) instead of a string in order to more quickly test if a char is in that set