### PR TITLE
Fix a bug

### DIFF
--- a/mathbot/modules/dice.py
+++ b/mathbot/modules/dice.py
@@ -92,8 +92,8 @@ class DiceModule(core.module.Module):
 			return self.gaussian_roll_single(dice, faces)
 		# passing this second test means we can do multiple rolls safely
 		elif math.log2(faces) < (PREC / 2):
-			dice_per = PREC - round(math.log2(faces))
-			times = round(dice / 2**(dice_per))
+			dice_per = 2**(PREC - round(math.log2(faces)))
+			times = round(dice / dice_per)
 			if times > limit:
 				raise ValuesTooBigException()
 			return sum([self.gaussian_roll_single(dice_per, faces) for _ in range(times)])


### PR DESCRIPTION
There was a bug where queries such as 
`=roll 10000000000000000d2`
would give tiny results, like 150.

I am slightly tipsy so i'd recommend you double check that this didn't break anything. If this is fixed correctly then 
`=roll 1000000000000000d2`
should give a smaller result than
`=roll 10000000000000000d2`