### PR TITLE
Increases the effiency & accuracy of permission_names

### DIFF
--- a/mathbot/core/util.py
+++ b/mathbot/core/util.py
@@ -3,41 +3,10 @@ import functools
 import discord
 import discord.ext.commands
 
-permission_attributes = [
-	'create_instant_invite',
-	'kick_members',
-	'ban_members',
-	'administrator',
-	'manage_channels',
-	'manage_server',
-	'add_reactions',
-	'view_audit_logs',
-	'read_messages',
-	'send_messages',
-	'send_tts_messages',
-	'manage_messages',
-	'embed_links',
-	'attach_files',
-	'read_message_history',
-	'mention_everyone',
-	'external_emojis',
-	'connect',
-	'speak',
-	'mute_members',
-	'deafen_members',
-	'move_members',
-	'use_voice_activation',
-	'change_nickname',
-	'manage_nicknames',
-	'manage_roles',
-	'manage_webhooks',
-	'manage_emojis'
-]
-
 def permission_names(perm):
-	for i in permission_attributes:
-		if getattr(perm, i):
-			yield i.replace('_', ' ').title()
+	for permission, has in perm:
+		if has:
+			yield permission.replace('_', ' ').title()
 
 # Decorator to make command respond with whatever the command returns
 def respond(coro):


### PR DESCRIPTION
The current permission_attributes lists outdated permissions.
Hence, this has been removed, and replaced with iter(discord.Permissions).
This new way both returns if it has it, and the name which can
be used dynamically without needing prior knowledge of available
permissions