### PR TITLE
Fix a bug with glyphs as function arguments

### DIFF
--- a/mathbot/calculator/interpereter.py
+++ b/mathbot/calculator/interpereter.py
@@ -41,7 +41,7 @@ class IndexedScope:
 		while depth > 0:
 			scope = scope.superscope
 			depth -= 1
-		if index >= len(scope.slots) or scope.slots[index].value == None:
+		if index >= len(scope.slots) or scope.slots[index].value is None:
 			raise ScopeMissedError
 		return scope.slots[index].value
 


### PR DESCRIPTION
When a function was called with a glyph as its argument, the bot would complain that a glyph can't be compared to a non-glyph. This is because at this point in the code the calculator would check `Glyph-object == None`.