### PR TITLE
Resolution for redis connection error + minor text fix for readme command-line arguments.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 cffi = "*"
 aiohttp = "==3.3.2"
 sympy = "*"
-aioredis = "==1.0"
+aioredis = "==1.2.0"
 coverage = "*"
 expiringdict = {git = "https://github.com/mailgun/expiringdict.git", ref = "2fa0e533c2737e89ccaf66e72b497f5a654d2607"}
 "discord.py" = {git = "https://github.com/Rapptz/discord.py", ref = "607771c4f49a12d984d782883a580e7332359a10"}

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 cffi = "*"
 aiohttp = "==3.3.2"
 sympy = "*"
-aioredis = "==0.3.0"
+aioredis = "==1.0"
 coverage = "*"
 expiringdict = {git = "https://github.com/mailgun/expiringdict.git", ref = "2fa0e533c2737e89ccaf66e72b497f5a654d2607"}
 "discord.py" = {git = "https://github.com/Rapptz/discord.py", ref = "607771c4f49a12d984d782883a580e7332359a10"}

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Then open parameters.json and change `tokens` to the token of the bot used for d
 
 It is *strongly* recommend that you setup an instance of Redis if you want to use the bot on even a moderate scale. The disk-based keystore is easy to setup but runs very slowly, and as such is only useful of a development tool.
 
-Then navigate into the `mathbot` directory and run the bot with `python bot.py parameters.json`.
+Then navigate into the `mathbot` directory and run the bot with `python entrypoint.py parameters.json`.
 
 ## Setup for development
 
@@ -44,7 +44,7 @@ pipenv install --dev --skip-lock
 
 Then open parameters.json and change `tokens` to the token of the bot. Change `release` to `development`. Optionally change the other parameters.
 
-Then navigate into the `mathbot` directory and run the bot with `python bot.py parameters.json`.
+Then navigate into the `mathbot` directory and run the bot with `python entrypoint.py parameters.json`.
 
 ## Contributing guide
 

--- a/mathbot/core/keystore.py
+++ b/mathbot/core/keystore.py
@@ -61,7 +61,7 @@ class Redis(Driver):
 				user, password, host, port = re.split(r':|@', self.url[8:])
 				if password == '':
 					password = None
-				self.connection = await aioredis.create_reconnecting_redis(
+				self.connection = await aioredis.create_redis_pool(
 					(host, int(port)),
 					password = password,
 					db = self.db_number


### PR DESCRIPTION
Resolves #49 in its entirety. 

As of 1.0, aioredis module uses a different function for redis connection.

Instead of `create_reconnecting_redis()` it uses `create_redis_pool()`. 

[1.2.0 aioredis documentation](https://aioredis.readthedocs.io/en/v1.2.0/migration.html?highlight=create_reconnecting_redis)

The minor change in the readme also changes from `bot.py` to `entrypoint.py` which is the main process now.