### PR TITLE
Improve error handling in =tex

### DIFF
--- a/mathbot/modules/latex/__init__.py
+++ b/mathbot/modules/latex/__init__.py
@@ -132,8 +132,12 @@ class LatexModule(Cog):
 					sent_message = await guard.send(file=discord.File(render_result, 'latex.png'))
 					await self.bot.advertise_to(message.author, message.channel, guard)
 					if await self.bot.settings.resolve_message('f-tex-delete', message):
-						with suppress(discord.errors.NotFound):
+						try:
 							await message.delete()
+						except discord.errors.NotFound:
+							pass
+						except discord.errors.Forbidden:
+							await guard.send('Failed to delete source message automatically - either grant the bot "Manage Messages" permissions or disable `f-tex-delete`')
 
 				if sent_message and await self.bot.settings.resolve_message('f-tex-trashcan', message):
 					with suppress(discord.errors.NotFound):

--- a/mathbot/modules/latex/__init__.py
+++ b/mathbot/modules/latex/__init__.py
@@ -131,13 +131,13 @@ class LatexModule(Cog):
 				else:
 					sent_message = await guard.send(file=discord.File(render_result, 'latex.png'))
 					await self.bot.advertise_to(message.author, message.channel, guard)
-				if sent_message:
-					if await self.bot.settings.resolve_message('f-tex-trashcan', message):
-						with suppress(discord.errors.NotFound):
-							await sent_message.add_reaction(DELETE_EMOJI)
 					if await self.bot.settings.resolve_message('f-tex-delete', message):
 						with suppress(discord.errors.NotFound):
 							await message.delete()
+
+				if sent_message and await self.bot.settings.resolve_message('f-tex-trashcan', message):
+					with suppress(discord.errors.NotFound):
+						await sent_message.add_reaction(DELETE_EMOJI)
 
 	@Cog.listener()
 	async def on_reaction_add(self, reaction, user):


### PR DESCRIPTION
The source message now only gets deleted if the command was successful. Additionally, missing permissions to delete the source message are now handled gracefully with a helpful warning instead of an internal error.