### PR TITLE
added spoiler inputs and outputs

### DIFF
--- a/mathbot/modules/latex/__init__.py
+++ b/mathbot/modules/latex/__init__.py
@@ -28,7 +28,7 @@ core.help.load_from_file('./help/latex.md')
 
 LATEX_SERVER_URL = 'http://rtex.probablyaweb.site/api/v2'
 DELETE_EMOJI = '🗑'
-
+SPOILER_REGEXP = re.compile(r'\|\|\s+.*\s+\|\|$')
 
 # Load data from external files
 
@@ -138,7 +138,7 @@ class LatexModule(Cog):
 					else:
 						sent_message = await guard.send('Rendering failed. Check your code. You can edit your existing message if needed.')
 				else:
-					sent_message = await guard.send(file=discord.File(render_result, 'latex.png'))
+					sent_message = await guard.send(file=discord.File(render_result, 'latex.png', spoiler=SPOILER_REGEXP.search(message.content)))
 					await self.bot.advertise_to(message.author, message.channel, guard)
 					if await self.bot.settings.resolve_message('f-tex-delete', message):
 						try:
@@ -236,6 +236,10 @@ def process_latex(latex, is_inline):
 	blockformat = re.match(BLOCKFORMAT_REGEX, latex)
 	if blockformat:
 		latex = blockformat[1].strip(' \n')
+	if SPOILER_REGEXP.search(latex):
+		latex = latex[3:-3]
+		print(latex)
+		latex = latex.replace('\\|\\|', '||')
 	for key, value in TEX_REPLACEMENTS.items():
 		if key in latex:
 			latex = latex.replace(key, value)


### PR DESCRIPTION
added support for using Discord's spoilerizing to the output images via modifications to how the latex raw text is processed
parsed based on the format `|| {content} ||`, not the space after the start `||` and before the end `||`. This means it still supports using `||` anywhere in the latex, even at the beginning and end, as long as spaces are used when a user wants to mark it as spoiler
example use:
`=tex || \frac{\rho_0}{P_0}=90.13 ||`
![image](https://user-images.githubusercontent.com/35200140/118881364-d820a780-b8a7-11eb-863f-fe87aa902e29.png)
![image](https://user-images.githubusercontent.com/35200140/118881378-dbb42e80-b8a7-11eb-94d9-825dc5dd1874.png)
